### PR TITLE
Fix cockpit disable functionality

### DIFF
--- a/stage-tipi/01-config/00-run.sh
+++ b/stage-tipi/01-config/00-run.sh
@@ -60,10 +60,14 @@ systemctl enable tipi-runtipi-retry.service
 systemctl enable avahi-daemon.service
 
 # ---- Cockpit — interface web de gestion système (port 9090) ----
-# Installé ici, mais désactivé par défaut.
-# L'utilisateur peut l'activer via le portail de configuration (case à cocher).
+# Installé ici, mais masqué par défaut (disable seul ne suffit pas : les presets
+# APT/systemd peuvent le ré-activer au premier démarrage).
+# L'utilisateur peut l'activer via le portail de configuration (case à cocher) ;
+# setup.py fait un unmask + enable --now à ce moment-là.
 apt-get install -y cockpit
-systemctl disable cockpit.socket 2>/dev/null || true
+systemctl disable cockpit.socket  2>/dev/null || true
+systemctl mask    cockpit.socket  2>/dev/null || true
+systemctl mask    cockpit.service 2>/dev/null || true
 
 # ---- Activer SSH (désactivé par défaut sur Trixie) ----
 systemctl enable ssh.service

--- a/stage-tipi/01-config/files/app/setup.py
+++ b/stage-tipi/01-config/files/app/setup.py
@@ -425,10 +425,16 @@ def get_final_ip() -> str | None:
 def configure_cockpit(enabled: bool):
     if enabled:
         step(T["cockpit_step"])
+        # Le socket et le service sont masqués au build — il faut d'abord
+        # lever le masque avant de pouvoir les activer.
+        subprocess.run(["systemctl", "unmask", "cockpit.socket", "cockpit.service"],
+                       check=False, capture_output=True)
         subprocess.run(["systemctl", "enable", "--now", "cockpit.socket"], check=False)
         done(T["cockpit_done"])
     else:
         subprocess.run(["systemctl", "disable", "--now", "cockpit.socket"],
+                       check=False, capture_output=True)
+        subprocess.run(["systemctl", "mask", "cockpit.socket", "cockpit.service"],
                        check=False, capture_output=True)
 
 

--- a/stage-tipi/01-config/files/app/setup.py
+++ b/stage-tipi/01-config/files/app/setup.py
@@ -429,13 +429,19 @@ def configure_cockpit(enabled: bool):
         # lever le masque avant de pouvoir les activer.
         subprocess.run(["systemctl", "unmask", "cockpit.socket", "cockpit.service"],
                        check=False, capture_output=True)
-        subprocess.run(["systemctl", "enable", "--now", "cockpit.socket"], check=False)
-        done(T["cockpit_done"])
+        r = subprocess.run(["systemctl", "enable", "--now", "cockpit.socket"],
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            err(f"Cockpit : activation échouée — {(r.stderr or r.stdout).strip()}")
+        else:
+            done(T["cockpit_done"])
     else:
-        subprocess.run(["systemctl", "disable", "--now", "cockpit.socket"],
-                       check=False, capture_output=True)
-        subprocess.run(["systemctl", "mask", "cockpit.socket", "cockpit.service"],
-                       check=False, capture_output=True)
+        r1 = subprocess.run(["systemctl", "disable", "--now", "cockpit.socket"],
+                            capture_output=True, text=True)
+        r2 = subprocess.run(["systemctl", "mask", "cockpit.socket", "cockpit.service"],
+                            capture_output=True, text=True)
+        if r1.returncode != 0 or r2.returncode != 0:
+            err("Cockpit : désactivation incomplète — vérifier manuellement")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request improves the management of the Cockpit web interface service to ensure it is masked (fully disabled) by default, preventing it from being unintentionally enabled by system or package presets. It also updates the setup logic to properly unmask and enable Cockpit only when the user chooses to activate it, and to re-mask it when deactivated.

**Cockpit service management improvements:**

* In `stage-tipi/01-config/00-run.sh`, Cockpit is now both disabled and masked by default after installation, preventing it from being automatically enabled by APT or systemd presets on first boot.
* In `stage-tipi/01-config/files/app/setup.py`, the `configure_cockpit` function now unmasks both `cockpit.socket` and `cockpit.service` before enabling them when the user activates Cockpit, and masks them again when Cockpit is deactivated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Amélioration de la gestion de Cockpit : le service ne sera plus réactivé involontairement lors du provisioning du système. Configuration plus robuste du contrôle de démarrage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->