### PR TITLE
Fix excluded variable handling

### DIFF
--- a/stage-tipi/01-config/files/app/setup.py
+++ b/stage-tipi/01-config/files/app/setup.py
@@ -26,6 +26,7 @@ from translations import get_t
 # Nettoyage des codes ANSI (couleurs terminal) dans les sorties subprocess
 # ---------------------------------------------------------------------------
 _ANSI_RE = re.compile(r'\x1b\[[0-9;]*[mGKHFABCDJr]')
+_EXCLUDED_PREFIXES = ("10.42.", "169.254.")
 
 # ---------------------------------------------------------------------------
 # Patterns d'erreurs Docker fatales dans le flux de sortie du script Runtipi
@@ -434,7 +435,6 @@ def install_runtipi(max_attempts: int = 3) -> bool:
 
 
 def get_final_ip(max_wait: int = 30) -> str | None:
-    _EXCLUDED = ("10.42.", "169.254.")
     for _ in range(max_wait):
         for iface in ["eth0", "wlan0"]:
             try:
@@ -443,7 +443,7 @@ def get_final_ip(max_wait: int = 30) -> str | None:
                     capture_output=True, text=True,
                 )
                 m = re.search(r"inet\s+(\d+\.\d+\.\d+\.\d+)", r.stdout)
-                if m and not m.group(1).startswith(_EXCLUDED):
+                if m and not m.group(1).startswith(_EXCLUDED_PREFIXES):
                     return m.group(1)
             except Exception:
                 pass


### PR DESCRIPTION
This pull request refactors how excluded IP address prefixes are handled in the `setup.py` script. The main improvement is centralizing the excluded prefixes into a single constant, which makes the code cleaner and easier to maintain.

Refactoring and code cleanup:

* Introduced a module-level constant `_EXCLUDED_PREFIXES` to store the excluded IP address prefixes, replacing the previous use of a local variable.
* Updated the `get_final_ip` function to use `_EXCLUDED_PREFIXES` instead of a locally defined `_EXCLUDED` variable when checking if an IP address should be excluded. [[1]](diffhunk://#diff-9b78471b7450ddef93a2e7f93445f755e0d65b76822da16ed65043c8f875865dL437) [[2]](diffhunk://#diff-9b78471b7450ddef93a2e7f93445f755e0d65b76822da16ed65043c8f875865dL446-R446)