### PR TITLE
fix: install Runtipi in /opt instead of default location

### DIFF
--- a/stage-tipi/01-config/files/app/setup.py
+++ b/stage-tipi/01-config/files/app/setup.py
@@ -376,8 +376,6 @@ def _wait_for_internet(max_wait: int = 60) -> bool:
 
 def install_runtipi(max_attempts: int = 3) -> bool:
     step(T["runtipi_step"])
-    # Runtipi s'installe dans /opt (convention Linux pour les logiciels tiers système,
-    # cohérent avec le script Proxmox officiel qui utilise /opt/runtipi).
     for attempt in range(1, max_attempts + 1):
         if attempt > 1:
             out(T["runtipi_retry"].format(attempt=attempt, total=max_attempts))
@@ -395,7 +393,7 @@ def install_runtipi(max_attempts: int = 3) -> bool:
                 stderr=subprocess.STDOUT,
                 text=True,
                 bufsize=1,
-                cwd="/opt",
+                cwd="/opt",  # convention Linux pour les logiciels tiers (cohérent avec le script Proxmox officiel)
             )
             curl.stdout.close()
 

--- a/stage-tipi/01-config/files/app/setup.py
+++ b/stage-tipi/01-config/files/app/setup.py
@@ -378,7 +378,6 @@ def install_runtipi(max_attempts: int = 3) -> bool:
     step(T["runtipi_step"])
     # Runtipi s'installe dans /opt (convention Linux pour les logiciels tiers système,
     # cohérent avec le script Proxmox officiel qui utilise /opt/runtipi).
-    os.makedirs("/opt", exist_ok=True)
     for attempt in range(1, max_attempts + 1):
         if attempt > 1:
             out(T["runtipi_retry"].format(attempt=attempt, total=max_attempts))

--- a/stage-tipi/01-config/files/app/setup.py
+++ b/stage-tipi/01-config/files/app/setup.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 """
 RuntipiOS — Script d'installation système
 Lancé par app.py via subprocess. Toutes les sorties sont capturées et
@@ -376,6 +376,9 @@ def _wait_for_internet(max_wait: int = 60) -> bool:
 
 def install_runtipi(max_attempts: int = 3) -> bool:
     step(T["runtipi_step"])
+    # Runtipi s'installe dans /opt (convention Linux pour les logiciels tiers système,
+    # cohérent avec le script Proxmox officiel qui utilise /opt/runtipi).
+    os.makedirs("/opt", exist_ok=True)
     for attempt in range(1, max_attempts + 1):
         if attempt > 1:
             out(T["runtipi_retry"].format(attempt=attempt, total=max_attempts))
@@ -393,6 +396,7 @@ def install_runtipi(max_attempts: int = 3) -> bool:
                 stderr=subprocess.STDOUT,
                 text=True,
                 bufsize=1,
+                cwd="/opt",
             )
             curl.stdout.close()
 


### PR DESCRIPTION
## Context
Runtipi was being installed in the default directory used by its install
script. This PR explicitly sets `/opt` as the working directory, which is
the standard Linux convention for third-party software.

## Changes
- Set `cwd="/opt"` on the `Popen` call that runs the Runtipi install script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Corrections de bugs**
  * Amélioration de la fiabilité du processus d'installation système pour garantir une exécution correcte.

* **Chores**
  * Optimisations mineures du script de configuration pour renforcer la stabilité globale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->