### PR TITLE
fix: cleanup /opt/tipi-setup before reboot after first-boot setup

### DIFF
--- a/stage-tipi/01-config/files/app/app.py
+++ b/stage-tipi/01-config/files/app/app.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 """
 RuntipiOS — Portail de configuration (premier démarrage)
 Tourne sur le port 8080, accessible via :
@@ -9,6 +9,7 @@ Tourne sur le port 8080, accessible via :
 import json
 import os
 import re
+import shutil
 import subprocess
 import threading
 import time
@@ -446,6 +447,8 @@ def reboot():
     """Redémarre le Pi après un court délai (laisse la réponse partir)."""
     def _do_reboot():
         time.sleep(2)
+        # Nettoyage du portail de configuration (plus nécessaire après installation)
+        shutil.rmtree("/opt/tipi-setup", ignore_errors=True)
         subprocess.run(["systemctl", "reboot"], check=False)
     threading.Thread(target=_do_reboot, daemon=True).start()
     return jsonify({"ok": True})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Le répertoire de configuration initiale est désormais supprimé automatiquement après le redémarrage du système, garantissant un nettoyage approprié suite à l'installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->